### PR TITLE
👷 ci(workflows): 添加 Windows 环境测试

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,4 +42,6 @@ jobs:
       - name: build-storybook
         run: pnpm run build-storybook
       - name: Install dependencies
-        run: pnpm run storybook
+        run: |
+          - pnpm run storybook
+          - exit 0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,48 @@
+name: test
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        node-version: [21.6.2]
+        pnpm-version: [8.15.5]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js and dependencies
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ matrix.pnpm-version }}
+          run_install: false
+
+      - name: Get pnpm store directory
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-${{ matrix.pnpm-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-${{ matrix.pnpm-version }}-
+
+      - name: Install dependencies
+        run: pnpm install
+      - name: build-storybook
+        run: pnpm run build-storybook
+      - name: Install dependencies
+        run: |
+          - pnpm run storybook
+          - exit 0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  pnpm:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     runs-on: windows-2022
     strategy:
@@ -26,18 +26,6 @@ jobs:
           version: ${{ matrix.pnpm-version }}
           run_install: false
 
-      # - name: Get pnpm store directory
-      #   run: |
-      #     echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      # - name: Setup pnpm cache
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ${{ env.STORE_PATH }}
-      #     key: ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-${{ matrix.pnpm-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-${{ matrix.pnpm-version }}-
-
       - name: Install dependencies
         run: pnpm install
       - name: build-storybook
@@ -45,4 +33,50 @@ jobs:
       - name: Install dependencies
         run: |
           - pnpm run storybook
-          - exit 0
+
+  yarn:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        node-version: [21.6.2]
+        yarn-version: [1.22.2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js and dependencies
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: yarn install
+      - name: build-storybook
+        run: yarn run build-storybook
+      - name: Install dependencies
+        run: |
+          - yarn run storybook
+
+  npm:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        node-version: [21.6.2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js and dependencies
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+      - name: build-storybook
+        run: npm run build-storybook
+      - name: Install dependencies
+        run: |
+          - npm run storybook

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,17 +26,17 @@ jobs:
           version: ${{ matrix.pnpm-version }}
           run_install: false
 
-      - name: Get pnpm store directory
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      # - name: Get pnpm store directory
+      #   run: |
+      #     echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-${{ matrix.pnpm-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-${{ matrix.pnpm-version }}-
+      # - name: Setup pnpm cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ${{ env.STORE_PATH }}
+      #     key: ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-${{ matrix.pnpm-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-${{ matrix.pnpm-version }}-
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在 Windows 2022 上新增了一个名为“test”的 GitHub Actions 工作流程，该流程设置了 Node.js，安装了包管理工具（pnpm、yarn、npm），配置了 pnpm 缓存，安装了依赖项，并构建了 Storybook。

- **改进**
    - 修改了 Linux 工作流程中的“安装依赖项”步骤，通过使用多行脚本运行两个命令（`pnpm run storybook` 和 `exit 0`），改变了控制流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->